### PR TITLE
Migration from lab 2 to Lab3 and updated jupyterhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN mkdir /tmp/pandoc && \
 
 # Install a newer version of TeX Live, than the one available in yum repos
 # For converting to PDF
-ENV PATH /usr/local/texlive/2020/bin/x86_64-linux/:$PATH
+ENV PATH /usr/local/texlive/2021/bin/x86_64-linux/:$PATH
 RUN mkdir /tmp/texlive && \
     cd /tmp/texlive && \
     wget --quiet http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,9 +100,9 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
 
 RUN pip3 --no-cache-dir install \
             'ipyparallel' \
-            'notebook==6.1.3' \
+            'notebook==6.4.0' \
             'jupyterhub==1.1.0' \
-            'jupyterlab==2.2.6' \
+            'jupyterlab==3.0.15' \
             'jupyter_nbextensions_configurator' \
             'voila'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
 RUN pip3 --no-cache-dir install \
             'ipyparallel' \
             'notebook==6.4.0' \
-            'jupyterhub==1.1.0' \
+            'jupyterhub==1.4.1' \
             'jupyterlab==3.0.15' \
             'jupyter_nbextensions_configurator' \
             'voila'


### PR DESCRIPTION
Hello!
This PR allows to update the lab2 to lab3 and also the jupyterhub version was updated.

tested in swan-qa002 but we still need to update jupyterhub in puppet, I installed it manually with pip to tests it.

Cheers
Omar.