### PR TITLE
Pin ipyparallel to last known working version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     rm get-pip.py
 
 RUN pip3 --no-cache-dir install \
-            'ipyparallel' \
+            'ipyparallel==6.3.0' \
             'notebook==6.4.2' \
             'jupyterhub==1.4.2' \
             'jupyterlab==3.0.17' \


### PR DESCRIPTION
Later versions add a jupyterlab extension that shows popup errors due to missing serverextension etc.