### PR TITLE
Update to JH 4.0.2 and latest base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Another Docker container should inherit with `FROM cernphsft/notebook`
 # to run actual services.
 
-FROM gitlab-registry.cern.ch/linuxsupport/cc7-base:20210715-1.x86_64
+FROM gitlab-registry.cern.ch/linuxsupport/cc7-base:20230801-1.x86_64
 
 LABEL maintainer="swan-admins@cern.ch"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN mkdir /tmp/pandoc && \
 
 # Install a newer version of TeX Live, than the one available in yum repos
 # For converting to PDF
-ENV PATH /usr/local/texlive/2021/bin/x86_64-linux/:$PATH
+ENV PATH /usr/local/texlive/2023/bin/x86_64-linux/:$PATH
 RUN mkdir /tmp/texlive && \
     cd /tmp/texlive && \
     wget --quiet http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
 RUN pip3 --no-cache-dir install \
             'ipyparallel==6.3.0' \
             'notebook==6.4.2' \
-            'jupyterhub==1.4.2' \
+            'jupyterhub==4.0.2' \
             'jupyterlab==3.0.17' \
             'jupyter_nbextensions_configurator' \
             'voila'


### PR DESCRIPTION
As part of the upgrade of the JH version in swan-cern/jupyterhub-extensions/pull/82