### PR TITLE
Pin urllib3 version to 1.26.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,7 @@ RUN pip3 --no-cache-dir install \
             'ipyparallel==6.3.0' \
             'notebook==6.4.2' \
             'jupyterhub==4.0.2' \
+            'urllib3==1.26.16' \
             'jupyterlab==3.0.17' \
             'jupyter_nbextensions_configurator' \
             'voila'


### PR DESCRIPTION
That is the last version of the v1 series, which uses OpenSSL 1.0.2. If we don't pin it, then v2 is installed, which requires OpenSSL 1.1.1+, and we get this error:
ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168

This pinning can be removed when upgrading to Alma9, which has a newer version of OpenSSL.

This is part of the update to JH 4.